### PR TITLE
fix: point to new repo Nuxt layers

### DIFF
--- a/apps/space-tool-plugins/space-plugins/nuxt-base/README.md
+++ b/apps/space-tool-plugins/space-plugins/nuxt-base/README.md
@@ -10,7 +10,7 @@ In your `nuxt.config.ts`,
 export default defineNuxtConfig({
 	extends: [
 		[
-			'github:storyblok/space-tool-plugins/space-plugins/nuxt-base',
+			'github:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nuxt-base',
 			{ install: true },
 		],
 	],

--- a/apps/space-tool-plugins/space-plugins/nuxt-starter/nuxt.config.ts
+++ b/apps/space-tool-plugins/space-plugins/nuxt-starter/nuxt.config.ts
@@ -4,11 +4,11 @@ export default defineNuxtConfig({
 	ssr: false,
 	extends: [
 		[
-			'github:storyblok/space-tool-plugins/space-plugins/nuxt-base',
+			'github:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nuxt-base',
 			{ install: true },
 		],
 		[
-			'github:storyblok/space-tool-plugins/space-plugins/nuxt-base-ui',
+			'github:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nuxt-base-ui',
 			{ install: true },
 		],
 	],

--- a/apps/space-tool-plugins/space-plugins/nuxt-story-starter/nuxt.config.ts
+++ b/apps/space-tool-plugins/space-plugins/nuxt-story-starter/nuxt.config.ts
@@ -3,7 +3,7 @@ export default defineNuxtConfig({
 	devtools: { enabled: true },
 	extends: [
 		[
-			'github:storyblok/space-tool-plugins/space-plugins/nuxt-base',
+			'github:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nuxt-base',
 			{ install: true },
 		],
 	],

--- a/apps/space-tool-plugins/tool-plugins/nuxt-starter/nuxt.config.ts
+++ b/apps/space-tool-plugins/tool-plugins/nuxt-starter/nuxt.config.ts
@@ -4,11 +4,11 @@ export default defineNuxtConfig({
 	ssr: false,
 	extends: [
 		[
-			'github:storyblok/space-tool-plugins/space-plugins/nuxt-base',
+			'github:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nuxt-base',
 			{ install: true },
 		],
 		[
-			'github:storyblok/space-tool-plugins/space-plugins/nuxt-base-ui',
+			'github:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nuxt-base-ui',
 			{ install: true },
 		],
 	],


### PR DESCRIPTION
This pull request updates the Nuxt configuration in several plugin starter projects to use a new GitHub repository path for dependencies. The changes ensure that the plugins now extend from the correct, updated source in the `pluginsblok` organization instead of the old `storyblok` path.

Dependency path updates:

* Updated the `extends` paths in `nuxt.config.ts` for `nuxt-base` and `nuxt-base-ui` to use `github:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nuxt-base` and `github:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nuxt-base-ui` in the following files:
  * `apps/space-tool-plugins/space-plugins/nuxt-starter/nuxt.config.ts`
  * `apps/space-tool-plugins/tool-plugins/nuxt-starter/nuxt.config.ts`
  * `apps/space-tool-plugins/space-plugins/nuxt-story-starter/nuxt.config.ts`
  * Documentation in `apps/space-tool-plugins/space-plugins/nuxt-base/README.md`