### PR TITLE
docs: replace old repo links or references by the new one at space-tool-plugins apps

### DIFF
--- a/apps/space-tool-plugins/space-plugins/nextjs-starter/README.md
+++ b/apps/space-tool-plugins/space-plugins/nextjs-starter/README.md
@@ -7,7 +7,7 @@ This is a starter template for Storyblok Space Plugins, created with Next.js (Pa
 ## Getting Started
 
 ```shell
-npx giget@latest gh:storyblok/space-tool-plugins/space-plugins/nextjs-starter YOUR-PROJECT-NAME
+npx giget@latest gh:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nextjs-starter YOUR-PROJECT-NAME
 ```
 
 ## How to run

--- a/apps/space-tool-plugins/space-plugins/nuxt-base/README.md
+++ b/apps/space-tool-plugins/space-plugins/nuxt-base/README.md
@@ -25,4 +25,4 @@ CLIENT_SECRET=
 BASE_URL=
 ```
 
-To learn more about the configuration, read the [space-plugin-nuxt-starter's README](https://github.com/storyblok/space-tool-plugins/blob/main/space-plugin-nuxt-starter/README.md#configuration).
+To learn more about the configuration, read the [space-plugin-nuxt-starter's README](https://github.com/storyblok/pluginsblok/blob/main/apps/space-tool-plugins/space-plugins/nuxt-starter#configuration).

--- a/apps/space-tool-plugins/space-plugins/nuxt-starter/README.md
+++ b/apps/space-tool-plugins/space-plugins/nuxt-starter/README.md
@@ -11,7 +11,7 @@ https://www.loom.com/share/f56defc5bfcf4fa8bce8682386f8352b?sid=8820f1b2-4229-4b
 ## Getting Started
 
 ```sh
-npx giget@latest gh:storyblok/space-tool-plugins/space-plugins/nuxt-starter YOUR-PROJECT-NAME
+npx giget@latest gh:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nuxt-starter YOUR-PROJECT-NAME
 ```
 
 This repository is developed using [pnpm](https://pnpm.io/). However, you can also use Yarn or NPM.

--- a/apps/space-tool-plugins/space-plugins/nuxt-story-starter/README.md
+++ b/apps/space-tool-plugins/space-plugins/nuxt-story-starter/README.md
@@ -18,10 +18,10 @@ The Story Starter is a [Space Plugin](https://www.storyblok.com/docs/plugins/cus
 > Currently, the Story Starter is written only in Nuxt. However, please inform us if you would like to have a Next.js version. Feel free to create a GitHub issue to make the request.
 
 ```sh
-npx giget@latest gh:storyblok/space-tool-plugins/space-plugins/nuxt-story-starter YOUR-PROJECT-NAME
+npx giget@latest gh:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nuxt-story-starter YOUR-PROJECT-NAME
 ```
 
-To learn more about the configuration, read the [nuxt-starter's README](https://github.com/storyblok/space-tool-plugins/tree/main/space-plugins/nuxt-starter#configuration).
+To learn more about the configuration, read the [nuxt-starter's README](https://github.com/storyblok/pluginsblok/blob/main/apps/space-tool-plugins/space-plugins/nuxt-story-starter#getting-started).
 
 ## Customization
 

--- a/apps/space-tool-plugins/space-plugins/nuxt-story-starter/README.md
+++ b/apps/space-tool-plugins/space-plugins/nuxt-story-starter/README.md
@@ -21,7 +21,7 @@ The Story Starter is a [Space Plugin](https://www.storyblok.com/docs/plugins/cus
 npx giget@latest gh:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nuxt-story-starter YOUR-PROJECT-NAME
 ```
 
-To learn more about the configuration, read the [nuxt-starter's README](https://github.com/storyblok/pluginsblok/blob/main/apps/space-tool-plugins/space-plugins/nuxt-story-starter#getting-started).
+To learn more about the configuration, read the [nuxt-starter's README](https://github.com/storyblok/pluginsblok/blob/main/apps/space-tool-plugins/space-plugins/nuxt-starter#configuration).
 
 ## Customization
 

--- a/apps/space-tool-plugins/tool-plugins/nextjs-starter/README.md
+++ b/apps/space-tool-plugins/tool-plugins/nextjs-starter/README.md
@@ -7,7 +7,7 @@ This is a starter template for Storyblok Tool plugins, created with Next.js (Pag
 ## Getting Started
 
 ```shell
-npx giget@latest gh:storyblok/space-tool-plugins/tool-plugins/nextjs-starter YOUR-PROJECT-NAME
+npx giget@latest gh:storyblok/pluginsblok/apps/space-tool-plugins/tool-plugins/nextjs-starter YOUR-PROJECT-NAME
 ```
 
 ## How to run

--- a/apps/space-tool-plugins/tool-plugins/nuxt-starter/README.md
+++ b/apps/space-tool-plugins/tool-plugins/nuxt-starter/README.md
@@ -5,7 +5,7 @@ This Nuxt starter is a Storyblok Tool Plugin that includes the basic authenticat
 ## Getting Started
 
 ```sh
-npx giget@latest gh:storyblok/space-tool-plugins/tool-plugins/nuxt-starter YOUR-PROJECT-NAME
+npx giget@latest gh:storyblok/pluginsblok/apps/space-tool-plugins/tool-plugins/nuxt-starter YOUR-PROJECT-NAME
 ```
 
 This repository is developed using [pnpm](https://pnpm.io/). However, you can also use Yarn or NPM.

--- a/packages/app-extension-auth/README.md
+++ b/packages/app-extension-auth/README.md
@@ -46,7 +46,7 @@ The parameter `AuthHandlerParams['cookieName']` has been renamed to `AuthHandler
 
 See our starters:
 
-- [Next.js](https://github.com/storyblok/space-tool-plugins/tree/main/space-plugins/nextjs-starter)
+- [Next.js](https://github.com/storyblok/pluginsblok/blob/main/apps/space-tool-plugins/space-plugins/nextjs-starter)
 
 ### Install the library
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates README links and giget commands to point from space-tool-plugins to pluginsblok paths.
> 
> - **Docs**
>   - **Space Plugins**:
>     - `space-plugins/nextjs-starter`: Update giget command to `gh:storyblok/pluginsblok/apps/space-tool-plugins/space-plugins/nextjs-starter`.
>     - `space-plugins/nuxt-base`: Update config link to `github.com/storyblok/pluginsblok/.../space-plugins/nuxt-starter#configuration`.
>     - `space-plugins/nuxt-starter`: Update giget command to `.../pluginsblok/.../space-plugins/nuxt-starter`.
>     - `space-plugins/nuxt-story-starter`: Update giget command and config link to `.../pluginsblok/...`.
>   - **Tool Plugins**:
>     - `tool-plugins/nextjs-starter`: Update giget command to `.../pluginsblok/.../tool-plugins/nextjs-starter`.
>     - `tool-plugins/nuxt-starter`: Update giget command to `.../pluginsblok/.../tool-plugins/nuxt-starter`.
>   - **Package**:
>     - `packages/app-extension-auth/README.md`: Update Next.js starter link to `.../pluginsblok/.../space-plugins/nextjs-starter`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd08aa648bb6d6301a6fcbf19db51397080136c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->