### PR TITLE
docs: update outdated links to Storyblok docs

### DIFF
--- a/apps/field-plugins/README.md
+++ b/apps/field-plugins/README.md
@@ -2,7 +2,7 @@
 
 # Field-type Examples
 
-A collection of field-types for Storyblok created by the community. Read more about creating field-types [here](https://www.storyblok.com/docs/plugins/field-type)
+A collection of field-types for Storyblok created by the community. Read more about creating field-types [here](https://www.storyblok.com/docs/plugins/field-plugins)
 
 <!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Table of Content) -->
 <details>

--- a/apps/field-plugins/folder-selection/README.md
+++ b/apps/field-plugins/folder-selection/README.md
@@ -43,7 +43,7 @@ yarn deploy
 
 5. Once the deployement is done successfully, you can continue its usage following the "Set up" section right below.
 
-Ps: If you are facing some issue performing these steps, you could also check our updated article on how to create and deploy field-plugins here: [Introduction to field-plugin](https://www.storyblok.com/docs/plugins/introduction).
+Ps: If you are facing some issue performing these steps, you could also check our updated article on how to create and deploy field-plugins here: [Introduction to field-plugin](https://www.storyblok.com/docs/plugins/field-plugins).
 
 # App Description
 

--- a/apps/field-plugins/hosted-plugin/README.md
+++ b/apps/field-plugins/hosted-plugin/README.md
@@ -24,4 +24,4 @@ A version of the hosted field plugin, has already been published and is free to 
 
 For detailed information on field plugins within Storyblok, check out the following articles:
 
-- [Introduction to Field Plugins](https://www.storyblok.com/docs/plugins/field-plugins/introduction)
+- [Introduction to Field Plugins](https://www.storyblok.com/docs/plugins/field-plugins)

--- a/apps/field-plugins/picker-starter/README.md
+++ b/apps/field-plugins/picker-starter/README.md
@@ -4,7 +4,7 @@
 | -------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | Picker Starter | A starter project for building e-commerce field plugins | [Demetrius Feijóo](https://github.com/demetriusfeijoo) & [Alba Silvente](https://github.com/Dawntraoz) |
 
-A starter project for building e-commerce [field plugins](https://www.storyblok.com/docs/plugins/field-plugins/introduction) and other “picker” field plugins – for example, integrations with digital asset management (DAM) systems.
+A starter project for building e-commerce [field plugins](https://www.storyblok.com/docs/plugins/field-plugins) and other “picker” field plugins – for example, integrations with digital asset management (DAM) systems.
 
 ![screenshot](./docs/screenshot.png)
 
@@ -12,7 +12,7 @@ The primary goal of this starter is to provide developers with a clear blueprint
 
 ## `picker.config.ts`
 
-The [`picker.config.ts`](./src/picker.config.ts) is a configuration file where you can customize the title, icon, tabs, filters, methods to perform queries, and also a method to validate the expected [plugin options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options).
+The [`picker.config.ts`](./src/picker.config.ts) is a configuration file where you can customize the title, icon, tabs, filters, methods to perform queries, and also a method to validate the expected [plugin options](https://www.storyblok.com/docs/plugins/field-plugins#options).
 
 In the example below you can have a glimpse of what this file looks like and its responsibilities:
 

--- a/apps/field-plugins/star-rating/README.md
+++ b/apps/field-plugins/star-rating/README.md
@@ -43,7 +43,7 @@ yarn deploy
 
 5. Once the deploy is done successfully, you can continue its usage following the "Set up" section right below.
 
-Ps: If you are facing some issue performing these steps, you could also check our updated article on how to create and deploy field-plugins here: [Introduction to field-plugin](https://www.storyblok.com/docs/plugins/introduction).
+Ps: If you are facing some issue performing these steps, you could also check our updated article on how to create and deploy field-plugins here: [Introduction to field-plugin](https://www.storyblok.com/docs/plugins/field-plugins).
 
 # App Description
 

--- a/apps/field-plugins/tags/README.md
+++ b/apps/field-plugins/tags/README.md
@@ -43,7 +43,7 @@ yarn deploy
 
 5. Once the deploy is done successfully, you can continue its usage following the "Set up" section right below.
 
-Ps: If you are facing some issue performing these steps, you could also check our updated article on how to create and deploy field-plugins here: [Introduction to field-plugin](https://www.storyblok.com/docs/plugins/introduction).
+Ps: If you are facing some issue performing these steps, you could also check our updated article on how to create and deploy field-plugins here: [Introduction to field-plugin](https://www.storyblok.com/docs/plugins/field-plugins).
 
 # App Description
 

--- a/apps/space-tool-plugins/README.md
+++ b/apps/space-tool-plugins/README.md
@@ -18,6 +18,6 @@ Inside each project you will find a detailed README.md file that will provide in
 
 ## Glossary
 
-- `Space Plugins`(also known as [Custom Sidebar Applications](https://www.storyblok.com/docs/plugins/custom-application)) are plugins that are present only once inside a space or organisation. Common Use-Cases for this kind of plugins are bulk operations on the content. One example of a Space Plugin is the [Broken Links Checker](https://www.storyblok.com/apps/storyblok-gmbh@broken-links-checker)
+- `Space Plugins`(also known as [Custom Sidebar Applications](https://www.storyblok.com/docs/plugins/space-plugins)) are plugins that are present only once inside a space or organisation. Common Use-Cases for this kind of plugins are bulk operations on the content. One example of a Space Plugin is the [Broken Links Checker](https://www.storyblok.com/apps/storyblok-gmbh@broken-links-checker)
 
-- `Tool Plugins` (also known as [Tools](https://www.storyblok.com/docs/plugins/tool)) are plugins that can be found within every story inside the tool section. These plugins usually provide operations on the story level. An example would be the [Export Translatable Fields Tool](https://www.storyblok.com/apps/export), which lets the user export all translatable fields of a story to either a JSON or XML format.
+- `Tool Plugins` (also known as [Tools](https://www.storyblok.com/docs/plugins/tool-plugins)) are plugins that can be found within every story inside the tool section. These plugins usually provide operations on the story level. An example would be the [Export Translatable Fields Tool](https://www.storyblok.com/apps/export), which lets the user export all translatable fields of a story to either a JSON or XML format.

--- a/apps/space-tool-plugins/space-plugins/nextjs-starter/README.md
+++ b/apps/space-tool-plugins/space-plugins/nextjs-starter/README.md
@@ -129,8 +129,8 @@ When deploying your Space Plugin, please remember to adjust the extension settin
 
 For more detailed information on Storyblok extensions, read the following guides:
 
-- [Space Plugin](https://www.storyblok.com/docs/plugins/custom-application)
-- [OAuth 2.0 Authorization Flow](https://www.storyblok.com/docs/plugins/authentication-apps)
+- [Space Plugin](https://www.storyblok.com/docs/plugins/space-plugins)
+- [OAuth 2.0 Authorization Flow](https://www.storyblok.com/docs/plugins/oauth-authorization-flow)
 
 ## Troubleshooting
 

--- a/apps/space-tool-plugins/space-plugins/nuxt-story-starter/README.md
+++ b/apps/space-tool-plugins/space-plugins/nuxt-story-starter/README.md
@@ -1,6 +1,6 @@
 # Story Starter
 
-The Story Starter is a [Space Plugin](https://www.storyblok.com/docs/plugins/custom-application) template that appears on the sidebar of your Storyblok space. It offers essential features for retrieving stories, enabling users to select specific ones, and performing actions. You can implement the actions you want to perform in `stories.config.ts`.
+The Story Starter is a [Space Plugin](https://www.storyblok.com/docs/plugins/space-plugins) template that appears on the sidebar of your Storyblok space. It offers essential features for retrieving stories, enabling users to select specific ones, and performing actions. You can implement the actions you want to perform in `stories.config.ts`.
 
 <p align="center">
   <img src="./docs/screenshot1.png" alt="Screenshot 1" width="600" />

--- a/apps/space-tool-plugins/tool-plugins/nextjs-starter/README.md
+++ b/apps/space-tool-plugins/tool-plugins/nextjs-starter/README.md
@@ -132,8 +132,8 @@ When deploying your Tool Plugin, please remember to adjust the tool settings ins
 
 For more detailed information on Storyblok extensions, read the following guides:
 
-- [Tool Plugins](https://www.storyblok.com/docs/plugins/tool)
-- [OAuth 2.0 Authorization Flow](https://www.storyblok.com/docs/plugins/authentication-apps)
+- [Tool Plugins](https://www.storyblok.com/docs/plugins/tool-plugins)
+- [OAuth 2.0 Authorization Flow](https://www.storyblok.com/docs/plugins/oauth-authorization-flow)
 
 ## Troubleshooting
 

--- a/packages/app-extension-auth/README.md
+++ b/packages/app-extension-auth/README.md
@@ -238,5 +238,5 @@ app.all('/api/connect/*', authHandler(params))
 
 ## Useful Resources
 
-- [Authentication Oauth2 flow](https://www.storyblok.com/docs/plugins/authentication-apps)
-- [Custom Applications](https://www.storyblok.com/docs/plugins/custom-application)
+- [Authentication Oauth2 flow](https://www.storyblok.com/docs/plugins/oauth-authorization-flow)
+- [Custom Applications](https://www.storyblok.com/docs/plugins/space-plugins)

--- a/packages/field-plugin/README.md
+++ b/packages/field-plugin/README.md
@@ -2,13 +2,13 @@
 
 Build custom fields for Storyblok with the `@storyblok/field-plugin` library and enhance the editing experience.
 
-It's easy to get started! Simply run [Storyblok's field plugin CLI](https://www.storyblok.com/docs/plugins/field-plugins/create) to generate a project from a template with your favorite frontend framework:
+It's easy to get started! Simply run [Storyblok's field plugin CLI](https://www.storyblok.com/docs/plugins/field-plugins/development#create-a-project) to generate a project from a template with your favorite frontend framework:
 
 ```shell
 npx @storyblok/field-plugin-cli@latest create
 ```
 
-For more details, please refer to the [documentation](https://www.storyblok.com/docs/plugins/field-plugins/introduction).
+For more details, please refer to the [documentation](https://www.storyblok.com/docs/plugins/field-plugins).
 
 ## Contributors
 

--- a/packages/field-plugin/packages/cli/README.md
+++ b/packages/field-plugin/packages/cli/README.md
@@ -132,7 +132,7 @@ Uploading your field plugin implementation to Storyblok Partner Portal can be pe
 
 [//]: # 'Add information about deploy and what is specifically does - uploading content of a file to SB, not building'
 
-> :warning: A token to access the [Storyblok Management API](https://www.storyblok.com/docs/api/management) for upserting the field plugin **must** be provided. There are two ways how to pass a token to the CLI.
+> :warning: A token to access the [Storyblok Management API](https://www.storyblok.com/docs/api/management/getting-started/authentication) for upserting the field plugin **must** be provided. There are two ways how to pass a token to the CLI.
 >
 > 1. provide `--token <STORYBLOK_PERSONAL_ACCESS_TOKEN>` inside the `deploy` command
 > 2. inside `.env` or `.env.local` create a new variable `STORYBLOK_PERSONAL_ACCESS_TOKEN`
@@ -195,9 +195,9 @@ We are working on providing templates for the popular frontend frameworks. Curre
 
 Now that everything is set up you can go ahead and checkout Storyblok's resource on field plugins:
 
-🔗 [Field Plugin Documentation](https://www.storyblok.com/docs/plugins/field-plugins/introduction)
+🔗 [Field Plugin Documentation](https://www.storyblok.com/docs/plugins/field-plugins)
 
-🔗 [Field Plugin Examples](https://github.com/storyblok/field-type-examples)
+🔗 [Field Plugin Examples](https://github.com/storyblok/pluginsblok/tree/main/apps/field-plugins)
 
 🔗 [Webinar Feature Focus: Field Plugin](https://www.youtube.com/watch?v=fvTWZCACDVQ)
 

--- a/packages/field-plugin/packages/cli/src/commands/deploy/helper.ts
+++ b/packages/field-plugin/packages/cli/src/commands/deploy/helper.ts
@@ -273,7 +273,7 @@ export const printManifestOptions = (options: ManifestOption[] | undefined) => {
     yellow(
       bold(
         `[info] Please note that the option values will not be shared when this field plugin is added to a story. Only keys are configured for security reasons.\n` +
-          `[info] Learn more: https://www.storyblok.com/docs/plugins/field-plugins/storyblok-field-plugin#manifest-file-for-field-plugins`,
+          `[info] Learn more: https://www.storyblok.com/docs/libraries/js/field-plugin-sdk#manifest-file`,
       ),
     ),
   )

--- a/packages/field-plugin/packages/cli/templates/js/README.md
+++ b/packages/field-plugin/packages/cli/templates/js/README.md
@@ -28,7 +28,7 @@ npm run deploy
 
 The manifest file is a configuration that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
 
-The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
+The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
 ### Configuring a Manifest File
 

--- a/packages/field-plugin/packages/cli/templates/react/README.md
+++ b/packages/field-plugin/packages/cli/templates/react/README.md
@@ -32,7 +32,7 @@ npm run deploy
 
 The manifest file is a configuration that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
 
-The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
+The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
 ### Configuring a Manifest File
 

--- a/packages/field-plugin/packages/cli/templates/vue2/README.md
+++ b/packages/field-plugin/packages/cli/templates/vue2/README.md
@@ -28,7 +28,7 @@ npm run deploy
 
 The manifest file is a configuration that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
 
-The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
+The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
 ### Configuring a Manifest File
 
@@ -77,4 +77,4 @@ npm run deploy --name $NAME --skipPrompts
 
 ## Design system
 
-We created our [blok.ink](https://www.storyblok.com/docs/guide/in-depth/design-system) design system to allow our customers to build great integrated experiences while maintaining Storyblok's overall design.
+We created our blok.ink design system to allow our customers to build great integrated experiences while maintaining Storyblok's overall design.

--- a/packages/field-plugin/packages/cli/templates/vue3/README.md
+++ b/packages/field-plugin/packages/cli/templates/vue3/README.md
@@ -34,7 +34,7 @@ npm run deploy
 
 The manifest file is a configuration that enhances the functionality of your field plugin. This JSON file, named `field-plugin.config.json` and located in your project's root folder, is optional but highly recommended.
 
-The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins/introduction#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin/), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
+The manifest file allows you to configure [options](https://www.storyblok.com/docs/plugins/field-plugins#options) for your field plugin. When developing your field plugin with the [Sandbox](https://plugin-sandbox.storyblok.com/field-plugin), the options are applied by default. Also, the deploy command automatically applies the options in production. So, you no longer need to configure the options manually.
 
 ### Configuring a Manifest File
 
@@ -85,4 +85,4 @@ npm run deploy --name $NAME --skipPrompts
 
 ## Design system
 
-We created our [blok.ink](https://www.storyblok.com/docs/guide/in-depth/design-system) design system to allow our customers to build great integrated experiences while maintaining Storyblok's overall design.
+We created our blok.ink design system to allow our customers to build great integrated experiences while maintaining Storyblok's overall design.

--- a/packages/field-plugin/packages/field-plugin/README.md
+++ b/packages/field-plugin/packages/field-plugin/README.md
@@ -2,13 +2,13 @@
 
 Build custom fields for Storyblok with the `@storyblok/field-plugin` library and enhance the editing experience.
 
-It's easy to get started! Simply run [Storyblok's field plugin CLI](https://www.storyblok.com/docs/plugins/field-plugins/create) to generate a project from a template with your favorite frontend framework:
+It's easy to get started! Simply run [Storyblok's field plugin CLI](https://www.storyblok.com/docs/plugins/field-plugins/development#create-a-project) to generate a project from a template with your favorite frontend framework:
 
 ```shell
 npx @storyblok/field-plugin-cli@latest create
 ```
 
-For more details, please refer to the [documentation](https://www.storyblok.com/docs/plugins/field-plugins/introduction).
+For more details, please refer to the [documentation](https://www.storyblok.com/docs/plugins/field-plugins).
 
 ## Contributors
 

--- a/packages/field-plugin/packages/sandbox/src/components/SandboxAppHeader.tsx
+++ b/packages/field-plugin/packages/sandbox/src/components/SandboxAppHeader.tsx
@@ -21,7 +21,7 @@ export const SandboxAppHeader: FunctionComponent = () => (
     >
       <ListItemButton
         component="a"
-        href="https://www.storyblok.com/docs/plugins/field-plugins/introduction"
+        href="https://www.storyblok.com/docs/plugins/field-plugins"
       >
         Documentation
       </ListItemButton>


### PR DESCRIPTION
This PR fixes broken links to Storyblok documentation found in multiple README and TS files, replacing outdated URLs with the correct and current ones.

It also closes #26.

(cc @demetriusfeijoo 👋)