### PR TITLE
chore(ci): harden publish workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,5 @@ packages/app-extension-auth @storyblok/plugins @storyblok/front-end
 packages/field-plugin @storyblok/plugins
 apps/field-plugins/* @storyblok/plugins @storyblok/front-end
 apps/space-tool-plugins/* @storyblok/plugins @storyblok/front-end
+.github/workflows/ @storyblok/dx
+.github/actions/ @storyblok/dx

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -1,20 +1,34 @@
 name: Setup Node
 description: Setup node
+inputs:
+  cache:
+    description: Restore/save pnpm and Nx caches
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
     - uses: ./.github/actions/cache-monorepo
+      if: ${{ inputs.cache == 'true' }}
 
     - name: Install pnpm
       uses: pnpm/action-setup@v2
       with:
         version: 10
 
-    - name: Setup Node.js
+    - name: Setup Node.js with cache
+      if: ${{ inputs.cache == 'true' }}
       uses: actions/setup-node@v4
       with:
         node-version-file: ".nvmrc"
         cache: "pnpm"
+
+    - name: Setup Node.js without cache
+      if: ${{ inputs.cache != 'true' }}
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: ".nvmrc"
+        package-manager-cache: false
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,12 +18,18 @@ env:
   HUSKY: 0
   NX_REJECT_UNKNOWN_LOCAL_CACHE: 0
 
+permissions:
+  contents: read
+
 jobs:
   build:
     environment: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - uses: ./.github/actions/setup-node
 
       - name: Check

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -20,6 +20,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.5.3
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,10 +18,12 @@ jobs:
         with:
           fetch-depth: 0
           filter: tree:0
+          persist-credentials: false
 
+      # Cache intentionally disabled — prevents cache poisoning of publish pipeline.
       - uses: ./.github/actions/setup-node
-
-      - run: pnpm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
+        with:
+          cache: "false"
 
       - name: Build publishable packages
         run: pnpm nx run-many -p="tag:npm:public" -t=build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,8 +23,12 @@ jobs:
           fetch-depth: 0
           filter: tree:0
           fetch-tags: true
+          persist-credentials: false
 
+      # Cache intentionally disabled — prevents cache poisoning of release pipeline.
       - uses: ./.github/actions/setup-node
+        with:
+          cache: "false"
 
       - name: Run tests, linting and building
         run: pnpm nx run-many --target=test --parallel=3 -p="tag:npm:public"
@@ -53,24 +57,24 @@ jobs:
           fetch-depth: 0
           filter: tree:0
           fetch-tags: true
+          persist-credentials: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Cache intentionally disabled — prevents cache poisoning of release pipeline.
       - uses: ./.github/actions/setup-node
+        with:
+          cache: "false"
 
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Configure npm authentication
-        run: pnpm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
-
       - name: Determine branch and npm tag
         id: release-info
         run: |
           BRANCH_NAME=${GITHUB_REF#refs/heads/}
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
-
           case "$BRANCH_NAME" in
             "main")
               echo "npm_tag=latest" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Make the publish and release workflows no-cache paths by adding a `cache`  input to `.github/actions/setup-node` and calling it with `cache: "false"`  from `publish.yaml` and `release.yaml`. This skips the shared pnpm/Nx cache composite and disables `actions/setup-node` package-manager caching while still running `pnpm install --frozen-lockfile`.
- Keep normal CI on the default cached setup path.
- Remove the redundant `NPM_TOKEN` authentication step from both `publish.yaml`
  and `release.yaml` — OIDC trusted publishing (`id-token: write`) is already configured and confirmed sufficient. The existing NPM_TOKEN in the org is expired (Mar 31, 2026) and has not been the active auth mechanism.
- Add `persist-credentials: false` to checkout steps that do not push.
- Pin `amannn/action-semantic-pull-request` in `commitlint.yaml` to an immutable commit SHA instead of the mutable `v5.5.3` tag.
- Add CODEOWNERS coverage for `.github/workflows/` and `.github/actions/` using `@storyblok/dx`.
- Add `persist-credentials: false` and explicit `contents: read` permission to `ci.yaml` to prevent token leakage via git config.

## Why

The publish and release jobs receive `id-token: write` for npm trusted
publishing, so they should not restore or save dependency/Nx caches that
could be influenced by other workflows. Strictly disabling caches in publish
is simpler and safer than maintaining a separate cache namespace for the
release path.

This mirrors the hardening applied to monoblok in [#606](https://github.com/storyblok/monoblok/pull/606) and was identified during a post-TanStack supply chain attack audit.

## Test plan

- [x] YAML parse for `.github/workflows/*` and `.github/actions/*`.
- [x] `git diff --check origin/main..HEAD`.
- [x] Confirmed `publish.yaml` keeps `contents: read` and `id-token: write`,
      uses `persist-credentials: false`, calls setup-node with `cache: "false"`,
      and has no `NPM_TOKEN` authentication step.
- [x] Confirmed `release.yaml` applies the same on both `dry-run` and `release`
      jobs, with no `Configure npm authentication` step.
- [x] Confirmed `ci.yaml` still uses the default cached setup path.

Jira: https://storyblok.atlassian.net/browse/INFRA-911