### PR TITLE
fix: changed how the browsers theme is detected

### DIFF
--- a/apps/field-plugins/tags/src/App.tsx
+++ b/apps/field-plugins/tags/src/App.tsx
@@ -6,8 +6,18 @@ import Tag from './components/Tag'
 
 const App: FunctionComponent = () => {
   useEffect(() => {
-    const theme = new URLSearchParams(window.location.search).get('theme')
-    document.documentElement.setAttribute('theme', theme ?? 'default')
+    const darkQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const applyTheme = (isDark: boolean) =>
+      document.documentElement.setAttribute(
+        'theme',
+        isDark ? 'dark' : 'default',
+      )
+    const handleChange = (event: MediaQueryListEvent) =>
+      applyTheme(event.matches)
+
+    applyTheme(darkQuery.matches)
+    darkQuery.addEventListener('change', handleChange)
+    return () => darkQuery.removeEventListener('change', handleChange)
   }, [])
   return (
     <FieldPluginProvider

--- a/apps/field-plugins/tags/src/style.scss
+++ b/apps/field-plugins/tags/src/style.scss
@@ -11,6 +11,8 @@ body {
   margin: 0;
   display: flex;
   box-sizing: border-box;
+  // !important: overrides CssBaseline's hardcoded white body background, whose injection order vs. ours flips between dev and build
+  background: transparent !important;
 }
 
 .MuiFormControl-root {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,8 @@ packages:
   - packages/field-plugin/packages/lib-helpers/*
   # plugin monorepo internal tools
   - tools/*
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: true
+  esbuild: true
+  nx: true


### PR DESCRIPTION
Jira Ticket:
https://storyblok.atlassian.net/browse/MNT-429#icft=MNT-429

## Description
Follow-up to #27. The Tag field plugin's background was reverting to white in production because MUI's `<CssBaseline />` hardcodes `body`'s background to the (non-theme-aware) `lightTheme.palette.background.default` (`#fff`). Since `#app` is transparent, that white `body` showed through — visible only in the built app because the injection order between our own styles and CssBaseline's emotion-injected global styles flips between dev and build.

While digging into why the dark theme wasn't applying either, found the actual root cause of MNT-429: the theme-detection added in #27 reads `theme` from `window.location.search`, which only ever reflects the **iframe's own URL**, not the parent Storyblok dashboard's theme. The container doesn't pass a `theme` param (confirmed via `@storyblok/field-plugin`'s message/URL-param types — no such field exists), so the plugin was always stuck on `theme="default"` regardless of the shell's actual theme.

Cross-origin restrictions mean the iframe can't read the parent document directly, so there's no way to know the Storyblok app's own theme toggle today. The closest available signal is the browser/OS-level `prefers-color-scheme`, which this PR switches to.

## Changes
- `App.tsx`: replaced the `?theme=` URL-param read with `window.matchMedia('(prefers-color-scheme: dark)')`, including a `change` listener so the field updates live if the OS scheme flips while it's open.
- `style.scss`: `body` background set to `transparent !important`, so it reliably overrides CssBaseline's hardcoded background regardless of style-injection order.

## Known limitation
This tracks the OS/browser color-scheme preference, not an independent in-app Storyblok theme toggle. If a user's OS is light but they've manually set Storyblok to dark (or vice versa), the field will follow the OS setting instead. Fixing that fully would require the field-plugin container to forward its own theme state into the iframe (via URL param or `postMessage`), which isn't part of the SDK today.

## Screenshot
<img width="1914" height="962" alt="Screenshot 2026-07-30 at 11 03 56" src="https://github.com/user-attachments/assets/2762e9e1-375d-4128-ac38-833f9408b299" />
