### PR TITLE
chore: sync field-plugin upstream (valibot 1.4.2, CVE-2025-66020)

### DIFF
--- a/packages/field-plugin/README.md
+++ b/packages/field-plugin/README.md
@@ -2,7 +2,7 @@
 
 Build custom fields for Storyblok with the `@storyblok/field-plugin` library and enhance the editing experience.
 
-It's easy to get started! Simply run [Storyblok's field plugin CLI](https://www.storyblok.com/docs/plugins/field-plugins/development#create-a-project) to generate a project from a template with your favorite frontend framework:
+It's easy to get started! Simply run [Storyblok's field plugin CLI](https://www.storyblok.com/docs/libraries/js/field-plugin-sdk) to generate a project from a template with your favorite frontend framework:
 
 ```shell
 npx @storyblok/field-plugin-cli@latest create

--- a/packages/field-plugin/packages/cli/package.json
+++ b/packages/field-plugin/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storyblok/field-plugin-cli",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/packages/field-plugin/packages/field-plugin/package.json
+++ b/packages/field-plugin/packages/field-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storyblok/field-plugin",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "SDK for creating Field Plugins for Storyblok.",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/field-plugin/packages/field-plugin/package.json
+++ b/packages/field-plugin/packages/field-plugin/package.json
@@ -59,7 +59,7 @@
     "vitest": "2.1.9"
   },
   "dependencies": {
-    "valibot": "1.1.0"
+    "valibot": "1.4.2"
   },
   "nx": {
     "implicitDependencies": [

--- a/packages/field-plugin/packages/field-plugin/src/createFieldPlugin/disableDefaultStoryblokStyles.ts
+++ b/packages/field-plugin/packages/field-plugin/src/createFieldPlugin/disableDefaultStoryblokStyles.ts
@@ -9,7 +9,5 @@ export const disableDefaultStoryblokStyles = (): (() => void) => {
 
   link?.setAttribute('disabled', '')
 
-  return () => {
-    link?.removeAttribute('disabled')
-  }
+  return () => {}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,8 +471,8 @@ importers:
   packages/field-plugin/packages/field-plugin:
     dependencies:
       valibot:
-        specifier: 1.1.0
-        version: 1.1.0(typescript@5.8.2)
+        specifier: 1.4.2
+        version: 1.4.2(typescript@5.8.2)
     devDependencies:
       "@storyblok/lib-helpers":
         specifier: workspace:*
@@ -12824,10 +12824,10 @@ packages:
       }
     engines: { node: ">=10.12.0" }
 
-  valibot@1.1.0:
+  valibot@1.4.2:
     resolution:
       {
-        integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==,
+        integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==,
       }
     peerDependencies:
       typescript: ">=5"
@@ -21894,7 +21894,7 @@ snapshots:
       "@types/istanbul-lib-coverage": 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@1.1.0(typescript@5.8.2):
+  valibot@1.4.2(typescript@5.8.2):
     optionalDependencies:
       typescript: 5.8.2
 


### PR DESCRIPTION
## Summary

Syncs `packages/field-plugin` with the five upstream `storyblok/field-plugin` commits that landed since the last migration, cherry-picked with original authorship preserved. Primary driver is the **high-severity valibot fix (CVE-2025-66020)**.

