### PR TITLE
chore: fix pnpm ignore builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,8 @@ packages:
   - packages/field-plugin/packages/lib-helpers/*
   # plugin monorepo internal tools
   - tools/*
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: true
+  esbuild: true
+  nx: true


### PR DESCRIPTION
## What

`pnpm install` was failing in recent versions of PNPM due to a new restriction on running scripts while installing dependencies.

<img width="524" height="104" alt="image" src="https://github.com/user-attachments/assets/59c18ed7-d01b-48c9-84d4-273b2b02b2fd" />

See: https://pnpm.io/cli/approve-builds


